### PR TITLE
Fix marker parentheses

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,14 +6,15 @@ import Ant hiding (fragmentProgram)
 import Lib
 import Language.Compiler
 import Language.Fragment
+import Language.Instruction(showInstruction)
 import Simulator.Options
 import Simulator.Runner
 import qualified Worlds
 
 -- Dumps the compiled program to stdout
 main :: IO ()
-main = print (length (compileProgram programReinier))
---main = putStrLn $ unlines $ map show $ compileProgram programReinier
+--main = print (length (compileProgram programReinier))
+main = putStrLn $ unlines $ map showInstruction $ compileProgram programReinier
 
 -- Runs the simulation
 runSim :: IO ()

--- a/src/Language/Codegen.hs
+++ b/src/Language/Codegen.hs
@@ -42,7 +42,7 @@ compile (Turn lorr f)               = singleBranch (In.Turn lorr) f
 
 doubleBranch :: (AntState -> AntState -> Instruction) -> Fragment -> Fragment -> AntState -> CompileState
 doubleBranch toInstruction f1 f2 stateNumber = do
-    (callF1, instructions) <- compile f1 (stateNumber + 1)
+    (callF1, instructions)  <- compile f1 (stateNumber + 1)
     (callF2, instructions') <- compile f2 (stateNumber + 1 + length instructions)
     return (stateNumber, toInstruction callF1 callF2 : instructions ++ instructions')
 

--- a/src/Language/Instruction.hs
+++ b/src/Language/Instruction.hs
@@ -5,8 +5,11 @@ module Language.Instruction (
     SenseDir(..),
     LeftOrRight(..),
     Condition(..),
-    Instruction(..)
+    Instruction(..),
+    showInstruction,
     ) where
+
+import Data.List (intercalate)
 
 type AntState = Int -- 0..9999
 type MarkerNumber = Int -- 0..5
@@ -35,7 +38,7 @@ data Condition
     | FoeMarker
     | Home
     | FoeHome
-    deriving (Show, Eq)
+    deriving (Eq, Show)
 
 data Instruction
     = Sense SenseDir AntState AntState Condition
@@ -46,4 +49,9 @@ data Instruction
     | Turn LeftOrRight AntState
     | Move AntState AntState
     | Flip InvChance AntState AntState
-    deriving (Show, Eq)
+    deriving (Eq, Show)
+
+
+showInstruction :: Instruction -> String
+showInstruction (Sense dir a1 a2 c) = intercalate " " ["Sense", show dir, show a1, show a2, show c]
+showInstruction x = show x


### PR DESCRIPTION
The ant simulator/compiler expects a sense marker syntax like this:

Sense Ahead 0 378 Marker 4

Haskell however made it:

Sense Ahead 0 378 (Marker 4)

Because it saw the nesting of the marker condition in the sense statement.

I implemented the showInstruction function to fix this problem. It could be made prettier if there is some way in Haskell to override the default Show behaviour, but that sounds too OO-like so it's probably impossible.